### PR TITLE
Increase the gRPC block size from 4MB to 50MB.

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -6,17 +6,17 @@ package main
 
 import (
 	"fmt"
+	"github.com/LightningPeach/lnd/lncfg"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strings"
 
-	macaroon "gopkg.in/macaroon.v2"
+	"gopkg.in/macaroon.v2"
 
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/build"
-	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/urfave/cli"
@@ -37,6 +37,10 @@ const (
 var (
 	defaultLndDir      = btcutil.AppDataDir("lnd", false)
 	defaultTLSCertPath = filepath.Join(defaultLndDir, defaultTLSCertFilename)
+
+	// maxMsgRecvSize is the largest message our client will receive. We
+	// set this to ~50Mb atm.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 50)
 )
 
 func fatal(err error) {
@@ -131,11 +135,10 @@ func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 
 	// We need to use a custom dialer so we can also connect to unix sockets
 	// and not just TCP addresses.
-	opts = append(
-		opts, grpc.WithDialer(
-			lncfg.ClientAddressDialer(defaultRPCPort),
-		),
-	)
+	genericDialer := lncfg.ClientAddressDialer(defaultRPCPort)
+	opts = append(opts, grpc.WithDialer(genericDialer))
+	opts = append(opts, grpc.WithDefaultCallOptions(maxMsgRecvSize))
+
 	conn, err := grpc.Dial(ctx.GlobalString("rpcserver"), opts...)
 	if err != nil {
 		fatal(fmt.Errorf("unable to connect to RPC server: %v", err))


### PR DESCRIPTION
    Recently, the output of `lncli describegraph` has hit the block size cap
    due to the expansion of the mainnet graph. Without this attempts to
    fetch the graph returns an error of:
    ```
    [lncli] rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4246753 vs. 4194304)
    ```